### PR TITLE
Rearrange_code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ bld/
 [Ll]og/
 
 .DS_Store
+.sesskey
+
+*/bot_data.db

--- a/data/add_channels_db.py
+++ b/data/add_channels_db.py
@@ -1,11 +1,13 @@
-from datetime import datetime, timezone
 from os import getenv
 
 from sqlalchemy_utils import create_database, database_exists
 
 from yt_bot.config import Base
-from yt_bot.models import Channel, UnknownChannel, UsageStat, Video
-from yt_bot.services import CSVService, Database
+from yt_bot.models import Channel
+from yt_bot.services import Database
+
+from data.paths import MUSIC_CSV, SUBSCRIPTIONS_CSV, UNCATEGORISED_CSV
+from data.workflows import load_channels_from_csv, prepare_channel_seed_rows
 
 db_uri = getenv("DB_URI")
 if not database_exists(db_uri):
@@ -14,30 +16,13 @@ if not database_exists(db_uri):
 db = Database(db_uri)
 db.create_tables(Base.metadata)
 
-uncategorised = CSVService.read_csv_list_dict("data/ke_blog.csv")
-music = CSVService.read_csv_list_dict("data/ke_music.csv")
-others = CSVService.read_csv_list_dict("data/my_subs.csv")
-uc_ids = {x["channel_id"] for x in uncategorised}
-others = [row for row in others if row["channel_id"] not in uc_ids]
-uncategorised.extend(others)
-
-
-for row in uncategorised:
-    row["category"] = "uncategorised"
-for row in music:
-    row["category"] = "music"
-
-music_ids = {x["channel_id"] for x in music}
-de_music = [
-    channel for channel in uncategorised if channel["channel_id"] not in music_ids
-]
-music.extend(de_music)
-
-now = datetime.now(timezone.utc)
-for row in music:
-    row["created_at"] = now
-    row["updated_at"] = now
+uncategorised, music, others = load_channels_from_csv(
+    str(UNCATEGORISED_CSV),
+    str(MUSIC_CSV),
+    str(SUBSCRIPTIONS_CSV),
+)
+channel_rows = prepare_channel_seed_rows(uncategorised, music, others)
 
 with db.session() as session:
-    session.bulk_insert_mappings(Channel, music)
+    session.bulk_insert_mappings(Channel, channel_rows)
     session.commit()

--- a/data/dl_my_subs.py
+++ b/data/dl_my_subs.py
@@ -3,12 +3,15 @@ Download subscriptions from my channel. Used an environment variable for this bu
 channel_id variable to any channel
 '''
 from os import getenv
+
 from dotenv import load_dotenv
-from yt_bot.services import CSVService,YoutubeService
+
+from data.paths import SUBSCRIPTIONS_CSV
+from yt_bot.services import CSVService, YoutubeService
 
 load_dotenv()
 
 yt = YoutubeService()
-channel_id = getenv('YT_CHANNEL_ID')
+channel_id = getenv("YT_CHANNEL_ID")
 my_subs = yt.get_channel_subscriptions(channel_id)
-CSVService.write_list_dict_to_csv(my_subs, 'my_subs.csv')
+CSVService.write_list_dict_to_csv(my_subs, str(SUBSCRIPTIONS_CSV))

--- a/data/paths.py
+++ b/data/paths.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+
+DATA_DIR = Path(__file__).resolve().parent
+UNCATEGORISED_CSV = DATA_DIR / "ke_blog.csv"
+MUSIC_CSV = DATA_DIR / "ke_music.csv"
+SUBSCRIPTIONS_CSV = DATA_DIR / "my_subs.csv"

--- a/data/tweet_videos.py
+++ b/data/tweet_videos.py
@@ -1,18 +1,16 @@
 from os import getenv
 
-import feedparser
 import tweepy
 
 from yt_bot.config import logger
-from yt_bot.domain.parser import (
+from yt_bot.domain.channel_discovery import discover_unknown_channels
+from yt_bot.domain.feed_parser import (
     add_videos_to_db,
-    filter_new_videos,
-    format_feed,
-    get_rss_feed,
-    get_video_ids_from_db,
+    fetch_new_channel_videos,
+    stamp_and_filter_feed,
 )
 from yt_bot.domain.twitter import format_tweet_text, send_tweet
-from yt_bot.models import Channel, UnknownChannel, UsageStat, Video
+from yt_bot.models import Channel, UsageStat, Video
 from yt_bot.services import Database, daily_rate_limit
 
 db = Database(getenv("DB_URI"))
@@ -35,71 +33,6 @@ def tweepy_obj():
         raise
 
 
-def fetch_filtered_feed(session, channel_id):
-    """
-    Fetch RSS feed and filter to new videos not yet in DB.
-    Args:
-        session: SQLAlchemy session
-        channel_id: YouTube channel ID
-
-    Returns:
-        List of new videos
-    """
-    video_ids = get_video_ids_from_db(session, Video, channel_id)
-    rss_link = get_rss_feed(channel_id)
-    feed = format_feed(feedparser.parse(rss_link))
-    return filter_new_videos(feed, video_ids)
-
-
-def discover_new_channels(session, feed, channel):
-    """
-    Log new channels found in feed (e.g. VEVO)
-    Args:
-        session: SQLAlchemy session
-        feed: List of videos
-        channel: Channel object
-    """
-    if not feed:
-        return
-    source_channel_id = channel.channel_id
-    unknown_channel_ids = {
-        entry["channel_id"]
-        for entry in feed
-        if entry.get("channel_id") and entry["channel_id"] != source_channel_id
-    }
-    if not unknown_channel_ids:
-        return
-
-    existing_channel_ids = {
-        row[0]
-        for row in session.query(Channel.channel_id)
-        .filter(Channel.channel_id.in_(unknown_channel_ids))
-        .all()
-    }
-    existing_unknown_ids = {
-        row[0]
-        for row in session.query(UnknownChannel.channel_id)
-        .filter(UnknownChannel.channel_id.in_(unknown_channel_ids))
-        .all()
-    }
-    new_channel_ids = unknown_channel_ids - existing_channel_ids - existing_unknown_ids
-    if not new_channel_ids:
-        return
-
-    session.add_all(
-        [
-            UnknownChannel(channel_id=new_channel_id, name=channel.name)
-            for new_channel_id in sorted(new_channel_ids)
-        ]
-    )
-    session.commit()
-
-    for new_channel_id in sorted(new_channel_ids):
-        logger.info(
-            f"New Channel from {channel.name}: https://www.youtube.com/channel/{new_channel_id}",
-        )
-
-
 @daily_rate_limit(max_calls=17, get_session=db.session, model=UsageStat)
 def tweet_videos(twitter, feed, channel):
     """Format and tweet videos."""
@@ -120,14 +53,12 @@ def run_bot():
         twitter = tweepy_obj()
 
         for idx, channel in enumerate(channels, start=1):
-            feed = fetch_filtered_feed(session, channel.channel_id)
-            discover_new_channels(session, feed, channel)
+            feed = fetch_new_channel_videos(session, channel.channel_id)
+            discover_unknown_channels(session, feed, channel)
             if not feed:
                 continue
-            feed = sorted(
-                [entry for entry in feed if entry["channel_id"] == channel.channel_id],
-                key=lambda entry: entry["published"],
-            )
+            feed = stamp_and_filter_feed(feed, channel.channel_id)
+            feed = sorted(feed, key=lambda entry: entry["published"])
 
             if feed:
                 logger.info(f"{idx} of {total} | {channel.name}: {len(feed)} videos")

--- a/data/workflows/__init__.py
+++ b/data/workflows/__init__.py
@@ -1,0 +1,1 @@
+from .channels import load_channels_from_csv, prepare_channel_seed_rows

--- a/data/workflows/channels.py
+++ b/data/workflows/channels.py
@@ -1,0 +1,56 @@
+from datetime import datetime, timezone
+
+from yt_bot.services import CSVService
+
+
+def _with_category(rows: list[dict], category: str) -> list[dict]:
+    for row in rows:
+        row["category"] = category
+    return rows
+
+
+def _merge_channel_lists(
+    uncategorised: list[dict],
+    music: list[dict],
+    others: list[dict],
+) -> list[dict]:
+    uncategorised_ids = {row["channel_id"] for row in uncategorised}
+    remaining = [row for row in others if row["channel_id"] not in uncategorised_ids]
+
+    all_uncategorised = _with_category(uncategorised + remaining, "uncategorised")
+    music_rows = _with_category(music, "music")
+    music_ids = {row["channel_id"] for row in music_rows}
+
+    non_music = [
+        row for row in all_uncategorised if row["channel_id"] not in music_ids
+    ]
+    return music_rows + non_music
+
+
+def _stamp_rows(rows: list[dict], now: datetime | None = None) -> list[dict]:
+    now = now or datetime.now(timezone.utc)
+    for row in rows:
+        row["created_at"] = now
+        row["updated_at"] = now
+    return rows
+
+
+def load_channels_from_csv(
+    uncategorised_csv_path: str,
+    music_csv_path: str,
+    others_csv_path: str,
+) -> tuple[list[dict], list[dict], list[dict]]:
+    uncategorised = CSVService.read_csv_list_dict(uncategorised_csv_path)
+    music = CSVService.read_csv_list_dict(music_csv_path)
+    others = CSVService.read_csv_list_dict(others_csv_path)
+    return uncategorised, music, others
+
+
+def prepare_channel_seed_rows(
+    uncategorised: list[dict],
+    music: list[dict],
+    others: list[dict],
+) -> list[dict]:
+    merged = _merge_channel_lists(uncategorised, music, others)
+    return _stamp_rows(merged)
+

--- a/yt_bot/config.py
+++ b/yt_bot/config.py
@@ -1,7 +1,7 @@
 from loguru import logger
 from os import getenv
 from sys import stderr
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 import pretty_errors
 
 Base = declarative_base()

--- a/yt_bot/domain/__init__.py
+++ b/yt_bot/domain/__init__.py
@@ -1,0 +1,2 @@
+from .channel_discovery import discover_unknown_channels
+from .feed_parser import fetch_new_channel_videos, stamp_and_filter_feed

--- a/yt_bot/domain/channel_discovery.py
+++ b/yt_bot/domain/channel_discovery.py
@@ -1,0 +1,47 @@
+from yt_bot.config import logger
+from yt_bot.models import Channel, UnknownChannel
+
+
+def discover_unknown_channels(session, feed: list[dict], source_channel) -> set[str]:
+    if not feed:
+        return set()
+    source_channel_id = source_channel.channel_id
+    unknown_channel_ids = {
+        entry["channel_id"]
+        for entry in feed
+        if entry.get("channel_id") and entry["channel_id"] != source_channel_id
+    }
+    if not unknown_channel_ids:
+        return set()
+
+    existing_channel_ids = {
+        row[0]
+        for row in session.query(Channel.channel_id)
+        .filter(Channel.channel_id.in_(unknown_channel_ids))
+        .all()
+    }
+    existing_unknown_ids = {
+        row[0]
+        for row in session.query(UnknownChannel.channel_id)
+        .filter(UnknownChannel.channel_id.in_(unknown_channel_ids))
+        .all()
+    }
+    new_channel_ids = unknown_channel_ids - existing_channel_ids - existing_unknown_ids
+    if not new_channel_ids:
+        return set()
+
+    session.add_all(
+        [
+            UnknownChannel(channel_id=channel_id, name=source_channel.name)
+            for channel_id in sorted(new_channel_ids)
+        ]
+    )
+    session.commit()
+
+    for channel_id in sorted(new_channel_ids):
+        logger.info(
+            f"New Channel from {source_channel.name}: "
+            f"https://www.youtube.com/channel/{channel_id}"
+        )
+    return new_channel_ids
+


### PR DESCRIPTION
## Summary
This PR refactors the ingestion architecture to improve extensibility and align module boundaries, with domain logic consolidated under `yt_bot/domain` and data scripts reduced to orchestration.

## What Changed
1. Refactored data scripts to be thinner and reusable:
- `data/add_channels_db.py`
- `data/add_video_db.py`
- `data/tweet_videos.py`
- `data/dl_my_subs.py`

2. Added reusable data/bootstrap helpers:
- `data/workflows/channels.py`
- `data/workflows/__init__.py`
- `data/paths.py`

3. Moved and consolidated feed parsing/ingestion logic into domain:
- Renamed `yt_bot/domain/parser.py` -> `yt_bot/domain/feed_parser.py`
- Merged ingestion functions into `feed_parser.py`:
  - `fetch_new_channel_videos`
  - `stamp_and_filter_feed`
- Added `yt_bot/domain/channel_discovery.py`
- Updated `yt_bot/domain/__init__.py` exports
- Removed now-obsolete module copies used during transition (`video_ingestion` in prior location)

4. Updated imports across scripts/tests to match new module layout.

5. Updated tests:
- Renamed `tests/domain/test_parser.py` -> `tests/domain/test_feed_parser.py`
- Added new tests for `feed_parser` ingestion behavior:
  - `fetch_new_channel_videos` happy path
  - `fetch_new_channel_videos` empty fallback
  - `stamp_and_filter_feed` stamping/filtering behavior
  - `stamp_and_filter_feed` empty input

6. Fixed SQLAlchemy 2.x deprecation warning:
- `yt_bot/config.py` now imports `declarative_base` from `sqlalchemy.orm` (instead of `sqlalchemy.ext.declarative`).

## Why
- Improves extensibility by centralizing feed/domain behavior in one place.
- Reduces duplication between ingestion/tweet workflows.
- Clarifies boundaries: domain logic in `yt_bot/domain`, orchestration in `data/`.
- Keeps behavior stable while making future jobs/features easier to add.

## Validation
- Ran test suite: `uv run pytest -q`
- Result: **25 passed**.